### PR TITLE
Link google sheet in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # SoftwareChatter
 Software engineering discussion group resources
+
+See also [discussion topics and meeting schedule](https://docs.google.com/spreadsheets/d/1U_GjjKlVdjp5sDP9QKeVZOX_cbuP49ZzzqPhpECEN_s/edit?usp=sharing)


### PR DESCRIPTION
Suggest we link to google sheet - otherwise missing for people not using Slack.